### PR TITLE
Fixed event binding for Opera 12.

### DIFF
--- a/transform/transform.js
+++ b/transform/transform.js
@@ -225,7 +225,7 @@
 				
 				$this.css(css);
 				if (opts.duration > 0) {
-					$this.one('webkitTransitionEnd oTransitionEnd transitionend', afterCompletion);
+					$this.one('webkitTransitionEnd oTransitionEnd otransitionend transitionend', afterCompletion);
 				}
 				else {
 					setTimeout(afterCompletion, 1);					
@@ -266,3 +266,4 @@
 	};
 	
 })(jQuery);
+


### PR DESCRIPTION
In Opera 12 they've changed naming convention for events (oTransitionEnd is now otransitionend), so event "oTransitionEnd" doesn't work in Opera 12 at all. I've added "otransitionend" into binding events.

http://www.opera.com/docs/specs/presto2.10/#m274
